### PR TITLE
connect to redis in docker-compose for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
         stack-version: ${{ matrix.stack }}
         enable-stack: true
 
+    - name: Set up Docker Compose
+      run: docker compose up -d
+
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true' && success()
       timeout-minutes: 15
@@ -85,3 +88,8 @@ jobs:
         verbose: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
+    - name: Tear down Docker Compose
+      if: always()
+      run: docker compose down

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - uuid
 - async
 - stm
+- bytestring
 
 default-extensions:
 - OverloadedStrings

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -4,21 +4,41 @@
 
 module Server where
 
-import Data.Aeson (ToJSON)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Aeson (ToJSON, encode)
+import qualified Data.ByteString as B
 import Data.Data (Proxy (Proxy))
+import Database.Redis (Connection, Reply, checkedConnect, defaultConnectInfo, echo, runRedis)
 import GHC.Generics (Generic)
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp (run)
-import Servant (Get, Server, (:<|>) (..), (:>))
+import Servant (
+  Get,
+  Handler,
+  Server,
+  err500,
+  errBody,
+  errHeaders,
+  throwError,
+  (:<|>) (..),
+  (:>),
+ )
 import Servant.API (JSON)
 import Servant.Server (serve)
 
 newtype StatusResponse = StatusResponse
   { status :: String
   }
-  deriving (Generic, Eq, Show, Ord)
+  deriving (Generic, Eq, Show)
 
 instance ToJSON StatusResponse
+
+newtype ErrorResponse = ErrorResponse
+  { message :: String
+  }
+  deriving (Generic, Eq, Show)
+
+instance ToJSON ErrorResponse
 
 type HealthcheckEndpoints =
   "health" :> "live" :> Get '[JSON] StatusResponse
@@ -27,19 +47,42 @@ type HealthcheckEndpoints =
 
 type API = HealthcheckEndpoints
 
-api :: Proxy API
-api = Proxy
+throw500With :: String -> Handler a
+throw500With msg =
+  throwError $
+    err500
+      { errBody = encode (ErrorResponse msg)
+      , errHeaders = [("Content-Type", "application/json")]
+      }
 
-app :: Application
-app = serve api server
+app :: IO Application
+app = do
+  connection <- checkedConnect defaultConnectInfo
+  pure $ buildApp connection
+
+buildApp :: Connection -> Application
+buildApp conn = serve api (server conn)
+ where
+  api :: Proxy API
+  api = Proxy
 
 runApp :: IO ()
-runApp = runServer
+runApp = app >>= run 8080
 
-runServer :: IO ()
-runServer = run 8080 app
+startup :: Connection -> IO (Either Reply B.ByteString)
+startup connection = runRedis connection (echo "hello")
 
-server :: Server API
-server = (pure ok) :<|> (pure ok) :<|> (pure ok)
+server :: Connection -> Server API
+server connection =
+  liveHandler
+    :<|> startupHandler connection
+    :<|> readyHandler
  where
   ok = StatusResponse "ok"
+  liveHandler = pure ok
+  readyHandler = pure ok
+  startupHandler conn = do
+    result <- liftIO $ startup conn
+    case result of
+      Right _ -> pure (StatusResponse "ok")
+      Left _ -> throw500With "Redis connection failed"

--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -17,7 +17,7 @@ spec = describe "Simple test" $ do
   prop "property-based unit test" $
     \l -> reverse (reverse l) == (l :: [Int])
 
-  with (return app) $ do
+  with app $ do
     describe "GET /health/live/" $ do
       it "responds with ok status" $ do
         let response = [json|{"status":"ok"}|]


### PR DESCRIPTION
In scope: 
* Update github actions CI to run `docker compose up/down` respectively before and after running the tests, so that in the tests we can try connecting to dockerised redis. Docker is pre-installed, so that should not delay too much the CI, but i haven't added any code for now to cache docker images, so unless the GA node does it automatically, the redis image is fetched everytime
* Update the startup probe handler to send a `echo` command to redis and return 500 if it fails (how do we test the failure mode?). Notice: only the startup probe checks the connection for now, but we have an option to update the liveness probe too, although there's a risk (if this was a real server) of cascading effects if redis is down. If the app cannot establish initially a connection with reids, it fails to start, but if the connection is interrupted later only the liveness is still ok 
* Make sure we connect to redis only once, and reuse the connection for subsequent checks

Not in scope: 
* Check if there's reconnection in place or not. I suspect no
* Cherck why the error message is not in json 
* Test the 500 

<img width="837" alt="Screenshot 2025-03-10 at 01 55 18" src="https://github.com/user-attachments/assets/306377c4-2d04-41ec-a424-eb4e3164be72" />
