### PR TITLE
add servant-checked-exceptions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - warp
 - servant
 - servant-server
+- servant-checked-exceptions
 - hedis
 - refined
 - uuid


### PR DESCRIPTION
Quite an overkilling library, but worth importing in case we will have time to model the errors very explicitly as it should be done in production contexts (eg, RedisConnectionissue etc) 