### PR TITLE
Redis config from env variables

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,8 @@ dependencies:
 - async
 - stm
 - bytestring
+- http-types
+- network
 
 default-extensions:
 - OverloadedStrings

--- a/src/Endpoints.hs
+++ b/src/Endpoints.hs
@@ -1,20 +1,18 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Endpoints where
+module Endpoints (API) where
 
-import Models (StatusResponse)
+import Models (DatabaseConnectionError, StatusResponse)
 import Servant (
   Get,
   (:<|>) (..),
   (:>),
  )
 import Servant.API (JSON)
+import Servant.Checked.Exceptions (Throws)
 
-type HealthcheckEndpoints =
-  "health" :> "live" :> Get '[JSON] StatusResponse
-    :<|> "health" :> "startup" :> Get '[JSON] StatusResponse
-    :<|> "health" :> "ready" :> Get '[JSON] StatusResponse
+type HealthcheckEndpoints = "healthcheck" :> Throws DatabaseConnectionError :> Get '[JSON] StatusResponse
 
 type ReservationEndpoints =
   "api" :> "v1" :> "events" :> Get '[JSON] StatusResponse

--- a/src/Models.hs
+++ b/src/Models.hs
@@ -1,27 +1,50 @@
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 
 module Models where
-import GHC.Generics (Generic)
-import Data.Aeson (ToJSON)
+
+import Control.Monad ((<=<))
+import Data.Aeson (ToJSON (toJSON), object, (.=))
 import Data.UUID (UUID)
+import Env (Error, Parser, auto, def, helpDef, nonempty, str, var)
 import GHC.Exts (IsString)
+import GHC.Generics (Generic)
+import Network.HTTP.Types (status500)
+import Network.Socket (PortNumber)
 import Refined (FromTo, RefineException, Refined, refine)
+import Servant.Checked.Exceptions (ErrStatus (toErrStatus))
 
-newtype StatusResponse = StatusResponse
-  { status :: String
+data ApplicationConfig = ApplicationConfig
+  { redisHost :: String
+  , redisPort :: PortNumber
   }
-  deriving (Generic, Eq, Show)
+  deriving (Eq, Show)
 
-instance ToJSON StatusResponse
+applicationConfigEnvParser :: Parser Error ApplicationConfig
+applicationConfigEnvParser =
+  ApplicationConfig
+    <$> var (str <=< nonempty) "REDIS_HOST" (def "localhost" <> helpDef (helpMessage "Redis host"))
+    <*> var auto "REDIS_PORT" (def 6379 <> helpDef (helpMessage "Redis port"))
+ where
+  helpMessage prefix value = prefix ++ "[default: " ++ show value ++ " ]"
 
-newtype ErrorResponse = ErrorResponse
-  { message :: String
-  }
-  deriving (Generic, Eq, Show)
+data StatusResponse = Ok deriving (Eq, Show)
+
+instance ToJSON StatusResponse where
+  toJSON Ok = object ["status" .= ("ok" :: String)]
+
+newtype ErrorResponse = ErrorResponse String deriving (Generic, Eq, Show)
 
 instance ToJSON ErrorResponse
+
+data DatabaseConnectionError = DatabaseConnectionError deriving (Eq, Show)
+
+instance ToJSON DatabaseConnectionError where
+  toJSON DatabaseConnectionError = object ["message" .= ("cannot connect to the database" :: String)]
+
+instance ErrStatus DatabaseConnectionError where
+  toErrStatus _ = status500
 
 newtype UserId = UserId UUID
   deriving (Eq, Show)

--- a/test/ModelsSpec.hs
+++ b/test/ModelsSpec.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module ModelsSpec where
+
+import Env (parsePure)
+import Models (
+  ApplicationConfig (ApplicationConfig),
+  applicationConfigEnvParser,
+ )
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.QuickCheck.Property ()
+
+spec :: Spec
+spec = describe "Models" $ do
+  describe "ApplicationConfig parser" $ do
+    it "can parse env variables when correctly set" $
+      parsePure applicationConfigEnvParser [("REDIS_HOST", "hello"), ("REDIS_PORT", "10")] `shouldBe` Right (ApplicationConfig "hello" 10)
+
+    it "can parse env variables when redis port is not set" $
+      parsePure applicationConfigEnvParser [("REDIS_HOST", "hello")] `shouldBe` Right (ApplicationConfig "hello" 6379)
+
+    it "uses default values when no env variable is set" $
+      parsePure applicationConfigEnvParser [] `shouldBe` Right (ApplicationConfig "localhost" 6379)

--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -2,12 +2,13 @@
 
 module ServerSpec where
 
-import Server (app)
+import Server (app, appWithConfig)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.QuickCheck (prop)
 import Test.Hspec.Wai (ResponseMatcher (matchStatus), get, shouldRespondWith, with)
 import Test.Hspec.Wai.JSON (json)
 import Test.QuickCheck.Property ()
+import Models (ApplicationConfig(..))
 
 spec :: Spec
 spec = describe "Simple test" $ do
@@ -18,17 +19,14 @@ spec = describe "Simple test" $ do
     \l -> reverse (reverse l) == (l :: [Int])
 
   with app $ do
-    describe "GET /health/live/" $ do
+    describe "GET /healthcheck/" $ do
       it "responds with ok status" $ do
-        let response = [json|{"status":"ok"}|]
-        get "/health/live/" `shouldRespondWith` response{matchStatus = 200}
+        let response = [json|{"data":{"status":"ok"}}|]
+        get "/healthcheck/" `shouldRespondWith` response{matchStatus = 200}
 
-    describe "GET /health/startup/" $ do
-      it "responds with ok status" $ do
-        let response = [json|{"status":"ok"}|]
-        get "/health/startup/" `shouldRespondWith` response{matchStatus = 200}
+  with (appWithConfig (ApplicationConfig "localhost" 6380)) $ do
+    describe "GET /healthcheck/" $ do
+      it "fails to connect to redis" $ do
+        let response = [json|{"err":{"message":"cannot connect to the database"}}|]
+        get "/healthcheck/" `shouldRespondWith` response{matchStatus = 500}
 
-    describe "GET /health/ready/" $ do
-      it "responds with ok status" $ do
-        let response = [json|{"status":"ok"}|]
-        get "/health/ready/" `shouldRespondWith` response{matchStatus = 200}


### PR DESCRIPTION
So we can unit test behaviour and responses of the healthcheck endpoint when the app is failing to connect to redis.
As part of this PR i'm also moving to adopt servant-checked-exceptions, although the main downside of it still remains (after many years) the fact that the envelop payload JSON shape is not configurable. While the latter fact would probably be unacceptable in a production capacity, I can live with it for a toy project 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces Redis configuration via environment variables by updating multiple components. The changes span across dependency management, endpoint exports, and model definitions to integrate new configuration types and error handling mechanisms. Server initialization is revamped to parse and use environment-derived settings, while test suites are enhanced to cover these new features.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
</div>