### PR TITLE
do not attempt at parsing empty env variables

### DIFF
--- a/src/Models.hs
+++ b/src/Models.hs
@@ -25,7 +25,7 @@ applicationConfigEnvParser :: Parser Error ApplicationConfig
 applicationConfigEnvParser =
   ApplicationConfig
     <$> var (str <=< nonempty) "REDIS_HOST" (def "localhost" <> helpDef (helpMessage "Redis host"))
-    <*> var auto "REDIS_PORT" (def 6379 <> helpDef (helpMessage "Redis port"))
+    <*> var (auto <=< nonempty) "REDIS_PORT" (def 6379 <> helpDef (helpMessage "Redis port"))
  where
   helpMessage prefix value = prefix ++ "[default: " ++ show value ++ " ]"
 

--- a/test/ModelsSpec.hs
+++ b/test/ModelsSpec.hs
@@ -2,7 +2,7 @@
 
 module ModelsSpec where
 
-import Env (parsePure)
+import Env (Error (EmptyError), parsePure)
 import Models (
   ApplicationConfig (ApplicationConfig),
   applicationConfigEnvParser,
@@ -21,3 +21,6 @@ spec = describe "Models" $ do
 
     it "uses default values when no env variable is set" $
       parsePure applicationConfigEnvParser [] `shouldBe` Right (ApplicationConfig "localhost" 6379)
+
+    it "failt to parse empty env variables" $
+      parsePure applicationConfigEnvParser [("REDIS_HOST", ""), ("REDIS_PORT", "")] `shouldBe` Left [("REDIS_HOST", EmptyError), ("REDIS_PORT", EmptyError)]


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This PR enhances environment variable parsing by adding validation for empty REDIS_PORT values. The implementation prevents processing of empty inputs, improving configuration reliability. Test coverage has been expanded with updated imports and a new test case that verifies proper error handling for empty environment variables.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>