### PR TITLE
improve rest design of reservation endpoints

### DIFF
--- a/src/Endpoints.hs
+++ b/src/Endpoints.hs
@@ -3,7 +3,7 @@
 
 module Endpoints (API) where
 
-import Models (CreateEventRequest, CreateEventResponse, DatabaseConnectionError, EventId, SeatAlreadyReserved, SeatId, Seats, StatusResponse)
+import Models (CreateEventRequest, CreateEventResponse, DatabaseConnectionError, EventId, HoldRequest, ReservationRequest, SeatCannotBeHeld, SeatCannotBeReserved, SeatId, Seats, StatusResponse)
 import Servant (
   Capture,
   Get,
@@ -21,7 +21,8 @@ type HealthcheckEndpoints = "healthcheck" :> Throws DatabaseConnectionError :> G
 
 type ReservationEndpoints =
   "api" :> "v1" :> "events" :> ReqBody '[JSON] CreateEventRequest :> PostCreated '[JSON] CreateEventResponse
-    :<|> "api" :> "v1" :> "events" :> Capture "event_id" EventId :> "seats" :> Get '[JSON] Seats
-    :<|> "api" :> "v1" :> "events" :> Capture "event_id" EventId :> "seats" :> Capture "seat_id" SeatId :> "hold" :> Throws SeatAlreadyReserved :> PostAccepted '[JSON] NoContent
+    :<|> "api" :> "v1" :> "events" :> Capture "event_id" EventId :> "seats" :> Get '[JSON] Seats -- TODO make it paginated
+    :<|> "api" :> "v1" :> "events" :> Capture "event_id" EventId :> "holds" :> ReqBody '[JSON] HoldRequest :> Throws SeatCannotBeHeld :> PostAccepted '[JSON] NoContent
+    :<|> "api" :> "v1" :> "events" :> Capture "event_id" EventId :> "reservations" :> ReqBody '[JSON] ReservationRequest :> Throws SeatCannotBeReserved :> PostAccepted '[JSON] NoContent
 
 type API = HealthcheckEndpoints


### PR DESCRIPTION
* I've decided for convenience to rely on DuplicateRecordFields as I'm only planning to use the record value names for automatic Aeson derivation of ToJSON/FromJSON typeclasses, but usually i would just avoid these GHC extensions, stick to standard Haskell, and place the models in different modules 
* Use entity names instead of verbs in REST urls for reservation and holding. 
* Move the granularity to be per event, not per seat. this forced me to provide a request body in both the reserve and hold endpoints. For now the request only carries the seatId 
* The response for now does not include any body, but at some point i will start returning potentially the id of the hold/reservation. In redis there will be no such id, we are not really creating a sql resource with id here, for that reason i'm not trying to be fully rest compliant, and I will just not return any id for now 
* What about user_id, as i need to identify the user making the hold/reservation? Coming soon, in another PR, the point is to use the authentication header for that 